### PR TITLE
Exclude blade files from inline html rule

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,7 +16,9 @@
 <!--    <rule ref="Generic.CodeAnalysis.UnnecessaryFinalModifier"/>-->
     <rule ref="Generic.ControlStructures.InlineControlStructure"/>
 <!--    <rule ref="Generic.Files.ByteOrderMark"/>-->
-    <rule ref="Generic.Files.InlineHTML"/>
+    <rule ref="Generic.Files.InlineHTML">
+        <exclude-pattern>*.blade.php</exclude-pattern>
+    </rule>
 <!--    <rule ref="Generic.Files.LineEndings">-->
 <!--        <properties>-->
 <!--            <property name="eolChar" value="\n"/>-->


### PR DESCRIPTION
In order to fix
```
FILE: /home/resources/views/partners/edit/prices/index.blade.php
----------------------------------------------------------------------
FOUND 1 ERROR AND 1 WARNING AFFECTING 1 LINE
----------------------------------------------------------------------
 1 | WARNING | No PHP code was found in this file and short open tags
   |         | are not allowed by this install of PHP. This file may
   |         | be using short open tags but PHP does not allow them.
 1 | ERROR   | PHP files must only contain PHP code
----------------------------------------------------------------------
```